### PR TITLE
Handle collisions for hard drop

### DIFF
--- a/src/boardState.ts
+++ b/src/boardState.ts
@@ -1,0 +1,43 @@
+export interface BoardState {
+  width: number;
+  depth: number;
+  height: number;
+  cells: boolean[][][];
+}
+
+const state: BoardState = {
+  width: 0,
+  depth: 0,
+  height: 0,
+  cells: []
+};
+
+export function initBoardState(width: number, depth: number, height: number) {
+  state.width = width;
+  state.depth = depth;
+  state.height = height;
+  state.cells = Array.from({ length: width }, () =>
+    Array.from({ length: height }, () => Array(depth).fill(false))
+  );
+}
+
+export function lowestEmptyY(x: number, z: number): number {
+  for (let y = 0; y < state.height; y++) {
+    if (!state.cells[x][y][z]) {
+      if (y === 0 || state.cells[x][y - 1][z]) {
+        return y;
+      }
+    }
+  }
+  return state.height - 1;
+}
+
+export function occupyCell(x: number, y: number, z: number) {
+  state.cells[x][y][z] = true;
+}
+
+export function isOccupied(x: number, y: number, z: number): boolean {
+  return state.cells[x][y][z];
+}
+
+export default state;

--- a/src/components/blockHardDrop.ts
+++ b/src/components/blockHardDrop.ts
@@ -1,0 +1,57 @@
+import AFRAME from 'aframe';
+import { lowestEmptyY, occupyCell } from '../boardState';
+
+export interface BlockHardDropData {
+  floorY: number;
+  boardWidth: number;
+  boardDepth: number;
+  boardHeight: number;
+}
+
+declare const AFrame: typeof AFRAME;
+
+export interface BlockHardDropComponent extends AFrame.Component {
+  data: BlockHardDropData;
+  onKeyDown: (e: KeyboardEvent) => void;
+  onTriggerDown: () => void;
+}
+
+AFRAME.registerComponent('block-hard-drop', {
+  schema: {
+    floorY: { type: 'number', default: 0.5 },
+    boardWidth: { type: 'number', default: 3 },
+    boardDepth: { type: 'number', default: 3 },
+    boardHeight: { type: 'number', default: 12 }
+  },
+  init(this: BlockHardDropComponent) {
+    this.onKeyDown = this.handleKeyDown.bind(this);
+    this.onTriggerDown = this.handleTriggerDown.bind(this);
+    window.addEventListener('keydown', this.onKeyDown);
+    this.el.sceneEl?.addEventListener('triggerdown', this.onTriggerDown);
+  },
+  remove(this: BlockHardDropComponent) {
+    window.removeEventListener('keydown', this.onKeyDown);
+    this.el.sceneEl?.removeEventListener('triggerdown', this.onTriggerDown);
+  },
+  handleKeyDown(this: BlockHardDropComponent, e: KeyboardEvent) {
+    if (e.code === 'Space') {
+      this.drop();
+    }
+  },
+  handleTriggerDown(this: BlockHardDropComponent) {
+    this.drop();
+  },
+  drop(this: BlockHardDropComponent) {
+    const pos = this.el.object3D.position;
+    const halfW = this.data.boardWidth / 2;
+    const halfD = this.data.boardDepth / 2;
+    const xIdx = Math.round(pos.x + halfW - 0.5);
+    const zIdx = Math.round(pos.z + halfD - 0.5);
+    const yIdx = lowestEmptyY(xIdx, zIdx);
+    pos.y = this.data.floorY + yIdx;
+    this.el.setAttribute('position', `${pos.x} ${pos.y} ${pos.z}`);
+    occupyCell(xIdx, yIdx, zIdx);
+    this.el.removeAttribute('block-movement');
+    this.el.emit('block-settled', { x: xIdx, y: yIdx, z: zIdx });
+  }
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { loadConfig } from './configLoader';
 import './components/gameBoard';
 import './components/gameBlock';
 import './components/blockMovement';
+import './components/blockHardDrop';
+import { initBoardState } from './boardState';
 
 function spawnNewBlock(
   scene: Element,
@@ -14,6 +16,11 @@ function spawnNewBlock(
   block.setAttribute('game-block', { color });
   block.setAttribute('position', `0 ${startY} 0`);
   block.setAttribute('block-movement', {
+    boardWidth: boardDims.width,
+    boardDepth: boardDims.depth,
+    boardHeight: boardDims.height
+  });
+  block.setAttribute('block-hard-drop', {
     boardWidth: boardDims.width,
     boardDepth: boardDims.depth,
     boardHeight: boardDims.height
@@ -39,17 +46,20 @@ async function init() {
     board.setAttribute('position', '0 0 -5');
     scene.appendChild(board);
 
+    const dims = {
+      width: boardSize.dimensions[0],
+      depth: boardSize.dimensions[1],
+      height: boardSize.dimensions[2]
+    };
+
+    initBoardState(dims.width, dims.depth, dims.height);
+
+    scene.addEventListener('block-settled', () => {
+      spawnNewBlock(board, '#fff', dims.height, dims);
+    });
+
     // Spawn the first block at the top of the board
-    spawnNewBlock(
-      board,
-      '#fff',
-      boardSize.dimensions[2],
-      {
-        width: boardSize.dimensions[0],
-        depth: boardSize.dimensions[1],
-        height: boardSize.dimensions[2]
-      }
-    );
+    spawnNewBlock(board, '#fff', dims.height, dims);
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
## Summary
- track occupied cells in a new `boardState` module
- extend `block-hard-drop` to compute landing position using board state
- initialize board state in `main.ts` and spawn a new block when one settles

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*